### PR TITLE
Layout improvements on small screens

### DIFF
--- a/Shared/ContentView.swift
+++ b/Shared/ContentView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import WidgetKit
 import BackgroundTasks
 
 enum ActiveSheet: Identifiable {
@@ -35,7 +36,12 @@ struct ContentView: View {
     @AppStorage(UserDefaults.inAppShowMilestonePercentageKey, store: UserDefaults.shared) var showMilestonePercentage: Bool = true
     @AppStorage(UserDefaults.inAppUseTrueBlackBackgroundKey, store: UserDefaults.shared) var useTrueBlackBackground: Bool = false
     
-    static let maxFrameHeight = DeviceType.isSmallPhone() ? 310 : 378.5
+//    static let maxFrameHeight = DeviceType.isSmallPhone() ? 310 : 378.5
+    @State private var maxFrameHeight = 378.5
+    @State private var rectangleSize: CGSize = .zero
+    @State private var rectangleCenter: CGPoint = .zero
+    
+    @State private var fadeInWidget = true
     
     @State var activeSheet: ActiveSheet?
     
@@ -50,21 +56,34 @@ struct ContentView: View {
                     .allowsTightening(true)
                     .frame(maxWidth: .infinity, alignment: .center)
                     .padding(.bottom, 5)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.6)
                     .accessibility(label: Text("Relay FM for Saint Jude 2021"))
                 Text("This app provides a widget to track the progress of the 2021 Relay FM St. Jude fundraiser. Add the widget to your Home Screen!")
                     .multilineTextAlignment(.center)
                     .allowsTightening(true)
-                    .minimumScaleFactor(0.8)
-                    .lineLimit(4)
+                    .minimumScaleFactor(0.7)
+                    .lineLimit(3)
                     .fixedSize(horizontal: false, vertical: true)
                     .frame(maxWidth: .infinity, alignment: .center)
                     .accessibility(label: Text("This app provides a widget to track the progress of the 2021 Relay FM Saint Jude fundraiser. Add the widget to your Home Screen!"))
+                    .padding(.bottom, 5)
                 Spacer()
                 Rectangle()
-                    .frame(minWidth: 0, maxWidth: 795, minHeight: 300, maxHeight: Self.maxFrameHeight)
+                    .frame(minWidth: 0, maxWidth: 795, maxHeight: 378.5)
                     .foregroundColor(.clear)
+                    .background(
+                        GeometryReader { geometry -> Color in
+                            DispatchQueue.main.async {
+                                let frame = geometry.frame(in: CoordinateSpace.global)
+                                self.maxFrameHeight = min(frame.size.height, 378.5) // 378.5
+                                self.rectangleCenter = CGPoint(x: frame.midX, y: frame.midY)
+                                self.rectangleSize = frame.size
+                            }
+                            return Color.clear
+                        })
                 Spacer()
-                VStack {
+                VStack{
                     Link("Visit the fundraiser!", destination: URL(string: "https://stjude.org/relay")!)
                         .font(.headline)
                         .foregroundColor(Color(.sRGB, red: 43 / 255, green: 54 / 255, blue: 61 / 255, opacity: 1))
@@ -108,6 +127,7 @@ struct ContentView: View {
                             
                     }
                 })
+                    .padding(.vertical, 5)
             }
             .accessibility(hidden: isWidgetFlipped)
             .padding()
@@ -149,6 +169,7 @@ struct ContentView: View {
     #endif
                 }
             }
+            .scaleEffect((self.isWidgetFlipped) ? 0.95 : 1.0)
             
             BlurView(effect: UIBlurEffect(style: .systemUltraThinMaterial))
                 .opacity((self.isWidgetFlipped) ? 1.0 : 0)
@@ -156,14 +177,13 @@ struct ContentView: View {
                 .onTapGesture(perform: {
                     self.dismissSettings()
                 })
-                
+            
             VStack {
                 if isWidgetFlipped {
                     WidgetSettingsView(onDismiss: self.dismissSettings)
                         .rotation3DEffect(.degrees(180), axis: (x: 0, y: 1, z: 0))
-                        .frame(minWidth: 0, maxWidth: 795, minHeight: 300, maxHeight: Self.maxFrameHeight)
                 } else {
-                    EntryView(campaign: $widgetData, showMilestones: showMilestones, showFullCurrencySymbol: showFullCurrencySymbol, showGoalPercentage: showGoalPercentage, showMilestonePercentage: showMilestonePercentage, useTrueBlackBackground: useTrueBlackBackground)
+                    EntryView(campaign: $widgetData, showMilestones: (self.maxFrameHeight/self.rectangleSize.width < 0.68) ? false : showMilestones, showFullCurrencySymbol: showFullCurrencySymbol, showGoalPercentage: showGoalPercentage, showMilestonePercentage: showMilestonePercentage, useTrueBlackBackground: useTrueBlackBackground, forceHidePreviousMilestone: (self.maxFrameHeight/self.rectangleSize.width < 0.75) ? true : false)
                         .onAppear {
 #if os(iOS)
                             submitRefreshTask()
@@ -176,9 +196,10 @@ struct ContentView: View {
                                 dataLogger.error("Failed to store API response: \(error.localizedDescription)")
                             }
                         }
+                        .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
                         .contextMenu {
                             Button {
-                                self.isWidgetFlipped = true
+                                self.showSettings()
                             } label: {
                                 Label("Edit Widget", systemImage: "info.circle")
                             }
@@ -187,14 +208,16 @@ struct ContentView: View {
             }
             .background(Color(UIColor.secondarySystemBackground))
             .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
-            .frame(minWidth: 0, maxWidth: 795, minHeight: 300, maxHeight: Self.maxFrameHeight)
+            .frame(minWidth: 0, maxWidth: 795, maxHeight: self.maxFrameHeight)
             .rotation3DEffect(.degrees(isWidgetFlipped ? 180 : 0), axis: (x: 0, y: 1, z: 0))
             .onTapGesture {
                 self.showSettings()
             }
             .padding()
+            .position(self.rectangleCenter)
             .shadow(radius: 20)
-            .padding(.top, DeviceType.isSmallPhone() ? 80 : 0)
+            .edgesIgnoringSafeArea(.all)
+//            .padding(.top, DeviceType.isSmallPhone() ? 80 : 0)
             .sheet(item: $activeSheet) { item in
                 switch item {
                 case .notifications:
@@ -206,7 +229,15 @@ struct ContentView: View {
                     }
                 }
             }
+            .opacity((!self.fadeInWidget) ? 1 : 0)
         }
+        .onAppear(perform: {
+            DispatchQueue.main.asyncAfter(deadline: .now()+0.1, execute: {
+                withAnimation(.spring(), {
+                    self.fadeInWidget = false
+                })
+            })
+        })
     }
     
     func showSettings() {

--- a/Shared/Views/EntryView.swift
+++ b/Shared/Views/EntryView.swift
@@ -16,9 +16,11 @@ struct EntryView: View {
     let showGoalPercentage: Bool
     let showMilestonePercentage: Bool
     let useTrueBlackBackground: Bool
+    var forceHidePreviousMilestone: Bool = false
 
     
     var showPreviousMilestone: Bool {
+        if(self.forceHidePreviousMilestone) { return false }
         return (isExtraLargeSize(family: family) || !DeviceType.isInWidget()) || campaign.nextMilestone == nil
     }
     


### PR DESCRIPTION
Widget now scales down if there isn't enough vertical space, and hides milestone elements as necessary
Widget is now properly lined up with space between text and buttons
Background zooms out a bit when blurring into settings
Context menu on widget now respects the corners
Widget fades in on first launch separately due to computed position
