### PR TITLE
Fetch Relay's campaign details from database once pulled from the API…

### DIFF
--- a/Shared/Views/CampaignView.swift
+++ b/Shared/Views/CampaignView.swift
@@ -353,6 +353,8 @@ struct CampaignView: View {
                 await updateCampaignFromAPI(for: relayCampaign)
             }
             
+            await fetch()
+            
         } else if let initialCampaign = initialCampaign {
             
             await updateCampaignFromAPI(for: initialCampaign, updateLocalCampaignState: true)


### PR DESCRIPTION
… on fundraiser page. Otherwise, milestones and rewards don't show up the first time you tap until you reload the view.